### PR TITLE
Lout out / swagger in

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There is only a single route exposed by the application:
 
 `/change?total={total}` - Which given an amount of currency (e.g. `$12.55`) will return an object comprised of the least possible number of coins to make up that denomination
 
-Documentation for this route is generated automatically and [exposed here](https://change-maker-api.herokuapp.com/docs).
+Documentation for this route is generated automatically and [exposed here](https://change-maker-api.herokuapp.com/documentation).
 
 **Note:** the denominations are currently a constant defined in `./server/api/make-change.js`
 

--- a/manifest.js
+++ b/manifest.js
@@ -31,6 +31,8 @@ const manifest = {
         plugin: 'vision'
     }, {
         plugin: 'lout'
+    }, {
+        plugin: 'hapi-swagger'
     }]
 };
 

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "confidence": "1.x.x",
     "glue": "3.x.x",
     "hapi": "13.x.x",
+    "hapi-swagger": "^4.2.1",
     "hoek": "3.x.x",
     "inert": "^3.2.0",
     "joi": "^8.0.3",
-    "lout": "^9.0.0",
     "vision": "^4.0.1"
   },
   "devDependencies": {

--- a/server/api/make-change.js
+++ b/server/api/make-change.js
@@ -14,7 +14,11 @@ exports.register = function (server, options, next) {
         config: {
             validate: {
                 query: {
-                    total: Joi.string().min(1).required()
+                    total: Joi
+                            .string()
+                            .min(1)
+                            .required()
+                            .description('the total amount to get change for')
                 }
             },
             description: 'Returns an object corresponding to the least possible number of coins for the given total',


### PR DESCRIPTION
Remove lout and add in Swagger (via `hapi-swagger`) as it's a much slicker experience and include a console to 'try out' the API in the UI